### PR TITLE
Add resolved URI to remote_file name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
-Copyright (C) 2015 YOUR_NAME
+Copyright (c) 2015 Ryan Larson and Ben Jansen
 
-All rights reserved - Do Not Redistribute
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -6,19 +6,48 @@ This cookbook provides resources for interacting with the artifactory REST API
 
 This is written in pure ruby so it supports all of teh platformz
 
-## Attributes
-
-## Usage
-
-This is basically `remote_file` where the source is defined as GAVC search parameters
+## Resources
 
 ### artifactory_rest_gavc_download
 
+This is basically `remote_file` where the source is defined as Artifactory GAVC search parameters.
+
+#### Attributes
+
+| Name | Type | Description | Default | Required
+| ---- | ---- | ----------- | ------- | --------
+| path | String | Path to directory in which file be downloaded | n/a | yes
+| endpoint | String | Artifactory instance URI | n/a | yes
+| group_id | String | Group for GAVC search | n/a | yes
+| artifact_id | String | Artifact for GAVC search | n/a | yes
+| version | String | Version for GAVC search | n/a | yes
+| classifier | String | Classifier for GAVC search | nil | no
+| packaging | String | File extension of artifact | n/a | yes
+| repository_keys | Array of strings | Repositories to search | n/a | yes
+
+#### Usage
+
+The following will download the commons-io-2.4-sources.jar file to `/tmp/downloads`, assuming that Artifactory
+at `http://artifactory.mycompany.com/artifactory` has that artifact in its `maven-central-cache` repository.
+
 ```ruby
-artifactory_rest_gavc_download
+artifactory_rest_gavc_download '/tmp/downloads' do
+  # Required
+  group_id 'commons-io'
+  artifact_id 'commons-io'
+  endpoint 'http://artifactory.mycompany.com/artifactory'
+  version '2.*'
+  repository_keys 'maven-central-cache'
+  packaging 'jar'
+
+  # Optional
+  classifier 'sources'
+end
 ```
 
 ## License and Authors
 
-Author:: Ryan Larson (<ryan.mango.larson@gmail.com>)
-Author:: Ben Jansen (<aogail@w007.org>)
+License: See the LICENSE file in this repository.
+
+  * Author:: Ryan Larson (<ryan.mango.larson@gmail.com>)
+  * Author:: Ben Jansen (<aogail@w007.org>)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ryan.mango.larson@gmail.com'
 license          'MIT'
 description      'Provides resources for interacting with the artifactory rest API'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 supports         'windows', '>= 7.0'
 supports         'centos', '>= 5.0'

--- a/providers/gavc_download.rb
+++ b/providers/gavc_download.rb
@@ -15,7 +15,7 @@ action :download do
                                                    packaging: new_resource.packaging)
 
     # Delegate to remote_file for idempotency
-    remote_file "Downloading file #{download_uri} by: #{new_resource.to_s}" do
+    remote_file "Downloading file #{download_uri} specified by: #{new_resource.to_s}" do
       source download_uri
       path new_resource.path
     end

--- a/providers/gavc_download.rb
+++ b/providers/gavc_download.rb
@@ -15,7 +15,7 @@ action :download do
                                                    packaging: new_resource.packaging)
 
     # Delegate to remote_file for idempotency
-    remote_file "Downloading file specificed by #{new_resource.to_s}" do
+    remote_file "Downloading file #{download_uri} by: #{new_resource.to_s}" do
       source download_uri
       path new_resource.path
     end

--- a/spec/gavc_download_spec.rb
+++ b/spec/gavc_download_spec.rb
@@ -5,61 +5,75 @@ require 'artifactory'
 
 def mock_commons_io(classifier: nil)
   allow(Artifactory::Resource::Artifact).to receive(:latest_version)
-                                                .with(group: 'commons-io', name: 'commons-io', version: '2.*', repos: 'repo')
+                                                .with(group: group_id, name: artifact_id, version: artifact_version, repos: repository_keys.first)
                                                 .and_return('2.4')
   allow(Artifactory::Resource::Artifact).to receive(:gavc_search)
-                                                .with(group: 'commons-io', name: 'commons-io', version: '2.4', repos: 'repo', classifier: classifier)
-                                                .and_return([double('artifact', download_uri: 'http://artifactory.example.com/artifactory/api/storage/libs-thirdparty-local/commons-io/commons-io/2.4/commons-io-2.4-sources.jar'),
-                                                             double('artifact', download_uri: 'http://artifactory.example.com/artifactory/api/storage/libs-thirdparty-local/commons-io/commons-io/2.4/commons-io-2.4.jar')])
+                                                .with(group: group_id, name: artifact_id, version: '2.4', repos: repository_keys.first, classifier: classifier)
+                                                .and_return([double('artifact', download_uri: download_uri)])
 end
 
 describe 'artifactory_rest_lwrp_test::gavc_download' do
+  let(:group_id) {'commons-io'}
+  let(:artifact_id) {'commons-io'}
+  let(:artifact_version) {'2.*'}
+  let(:repository_keys) {['repo']}
+  let(:endpoint) {'http://artifactory.example.com/artifactory'}
+  let(:resolved_version) {'2.4'}
+  let(:resolved_repo) {repository_keys.first}
+  let(:packaging) {'jar'}
+  let(:download_path) {'/tmp/download'}
+
+
   context 'with no classifier set' do
+    let(:download_uri) {"#{endpoint}/api/storage/#{resolved_repo}/#{group_id}/#{artifact_id}/#{resolved_version}/#{artifact_id}-#{resolved_version}.jar"}
     subject(:chef_run) do
       mock_commons_io
 
       ChefSpec::SoloRunner.new(step_into: ['artifactory_rest_gavc_download']) do |node|
-        node.set[:artifactory_rest][:gavc_download][:endpoint] = 'http://artifactory.example.com/artifactory'
-        node.set[:artifactory_rest][:gavc_download][:path] = '/tmp/download'
-        node.set[:artifactory_rest][:gavc_download][:group_id] = 'commons-io'
-        node.set[:artifactory_rest][:gavc_download][:artifact_id] = 'commons-io'
-        node.set[:artifactory_rest][:gavc_download][:version] = '2.*'
-        node.set[:artifactory_rest][:gavc_download][:packaging] = 'jar'
-        node.set[:artifactory_rest][:gavc_download][:repository_keys] = ['repo']
+        node.set[:artifactory_rest][:gavc_download][:endpoint] = endpoint
+        node.set[:artifactory_rest][:gavc_download][:path] = download_path
+        node.set[:artifactory_rest][:gavc_download][:group_id] = group_id
+        node.set[:artifactory_rest][:gavc_download][:artifact_id] = artifact_id
+        node.set[:artifactory_rest][:gavc_download][:version] = artifact_version
+        node.set[:artifactory_rest][:gavc_download][:packaging] = packaging
+        node.set[:artifactory_rest][:gavc_download][:repository_keys] = repository_keys
       end.converge(described_recipe)
     end
 
-    it { is_expected.to gavc_download(chef_run.node[:artifactory_rest][:gavc_download][:path])
-                            .with_group_id(chef_run.node[:artifactory_rest][:gavc_download][:group_id])
-                            .with_artifact_id(chef_run.node[:artifactory_rest][:gavc_download][:artifact_id])
-                            .with_version(chef_run.node[:artifactory_rest][:gavc_download][:version])
-                            .with_repository_keys(chef_run.node[:artifactory_rest][:gavc_download][:repository_keys])
-                            .with_endpoint(chef_run.node[:artifactory_rest][:gavc_download][:endpoint]) }
-    it { is_expected.to create_remote_file(/.*/).with_source('http://artifactory.example.com/artifactory/api/storage/libs-thirdparty-local/commons-io/commons-io/2.4/commons-io-2.4.jar') }
+    it { is_expected.to gavc_download(download_path)
+                            .with_group_id(group_id)
+                            .with_artifact_id(artifact_id)
+                            .with_version(artifact_version)
+                            .with_repository_keys(repository_keys)
+                            .with_endpoint(endpoint) }
+    it { is_expected.to create_remote_file(%r[.+#{download_uri}.+#{group_id}.+#{artifact_id}.+#{artifact_version}.+]).with_source(download_uri) }
   end
 
   context 'with classifier set' do
+    let(:download_uri) {"#{endpoint}/api/storage/#{resolved_repo}/#{group_id}/#{artifact_id}/#{resolved_version}/#{artifact_id}-#{resolved_version}-#{classifier}.jar"}
+    let(:classifier) {'sources'}
     subject(:chef_run) do
-      mock_commons_io(classifier: 'sources')
+      mock_commons_io(classifier: classifier)
 
       ChefSpec::SoloRunner.new(step_into: ['artifactory_rest_gavc_download']) do |node|
-        node.set[:artifactory_rest][:gavc_download][:endpoint] = 'http://artifactory.example.com/artifactory'
-        node.set[:artifactory_rest][:gavc_download][:path] = '/tmp/download'
-        node.set[:artifactory_rest][:gavc_download][:group_id] = 'commons-io'
-        node.set[:artifactory_rest][:gavc_download][:artifact_id] = 'commons-io'
-        node.set[:artifactory_rest][:gavc_download][:version] = '2.*'
-        node.set[:artifactory_rest][:gavc_download][:packaging] = 'jar'
-        node.set[:artifactory_rest][:gavc_download][:repository_keys] = ['repo']
-        node.set[:artifactory_rest][:gavc_download][:classifier] = 'sources'
+        node.set[:artifactory_rest][:gavc_download][:endpoint] = endpoint
+        node.set[:artifactory_rest][:gavc_download][:path] = download_path
+        node.set[:artifactory_rest][:gavc_download][:group_id] = group_id
+        node.set[:artifactory_rest][:gavc_download][:artifact_id] = artifact_id
+        node.set[:artifactory_rest][:gavc_download][:version] = artifact_version
+        node.set[:artifactory_rest][:gavc_download][:packaging] = packaging
+        node.set[:artifactory_rest][:gavc_download][:repository_keys] = repository_keys
+        node.set[:artifactory_rest][:gavc_download][:classifier] = classifier
       end.converge(described_recipe)
     end
 
-    it { is_expected.to gavc_download(chef_run.node[:artifactory_rest][:gavc_download][:path])
-                            .with_group_id(chef_run.node[:artifactory_rest][:gavc_download][:group_id])
-                            .with_artifact_id(chef_run.node[:artifactory_rest][:gavc_download][:artifact_id])
-                            .with_version(chef_run.node[:artifactory_rest][:gavc_download][:version])
-                            .with_repository_keys(chef_run.node[:artifactory_rest][:gavc_download][:repository_keys])
-                            .with_endpoint(chef_run.node[:artifactory_rest][:gavc_download][:endpoint]) }
-    it { is_expected.to create_remote_file(/.*/).with_source('http://artifactory.example.com/artifactory/api/storage/libs-thirdparty-local/commons-io/commons-io/2.4/commons-io-2.4-sources.jar') }
+    it { is_expected.to gavc_download(download_path)
+                            .with_group_id(group_id)
+                            .with_artifact_id(artifact_id)
+                            .with_version(artifact_version)
+                            .with_repository_keys(repository_keys)
+                            .with_endpoint(endpoint) }
+    it { is_expected.to create_remote_file(%r[.+#{download_uri}.+#{group_id}.+#{artifact_id}.+#{artifact_version}.+#{classifier}.+])
+                            .with_source(download_uri) }
   end
 end

--- a/spec/gavc_download_spec.rb
+++ b/spec/gavc_download_spec.rb
@@ -46,7 +46,7 @@ describe 'artifactory_rest_lwrp_test::gavc_download' do
                             .with_version(artifact_version)
                             .with_repository_keys(repository_keys)
                             .with_endpoint(endpoint) }
-    it { is_expected.to create_remote_file(%r[.+#{download_uri}.+#{group_id}.+#{artifact_id}.+#{artifact_version}.+]).with_source(download_uri) }
+    it { is_expected.to create_remote_file(%r[.+#{download_uri} specified by: .+#{group_id}.+#{artifact_id}.+#{artifact_version}.+]).with_source(download_uri) }
   end
 
   context 'with classifier set' do
@@ -73,7 +73,7 @@ describe 'artifactory_rest_lwrp_test::gavc_download' do
                             .with_version(artifact_version)
                             .with_repository_keys(repository_keys)
                             .with_endpoint(endpoint) }
-    it { is_expected.to create_remote_file(%r[.+#{download_uri}.+#{group_id}.+#{artifact_id}.+#{artifact_version}.+#{classifier}.+])
+    it { is_expected.to create_remote_file(%r[.+#{download_uri} specified by: .+#{group_id}.+#{artifact_id}.+#{artifact_version}.+#{classifier}.+])
                             .with_source(download_uri) }
   end
 end

--- a/test/cookbooks/artifactory_rest_lwrp_test/recipes/gavc_download.rb
+++ b/test/cookbooks/artifactory_rest_lwrp_test/recipes/gavc_download.rb
@@ -7,8 +7,8 @@ artifactory_rest_gavc_download node[:artifactory_rest][:gavc_download][:path] do
   artifact_id node[:artifactory_rest][:gavc_download][:artifact_id]
   version node[:artifactory_rest][:gavc_download][:version]
   repository_keys node[:artifactory_rest][:gavc_download][:repository_keys]
+  packaging node[:artifactory_rest][:gavc_download][:packaging]
 
   # Optional
   classifier node[:artifactory_rest][:gavc_download][:classifier] if node[:artifactory_rest][:gavc_download][:classifier]
-  packaging node[:artifactory_rest][:gavc_download][:packaging] if node[:artifactory_rest][:gavc_download][:packaging]
 end


### PR DESCRIPTION
Add the URI of the resolved artifact to the `remote_file` used to download the file. This way, the resolved artifact will appear in the chef log.
