### PR TITLE
move artifactory-server-authorization from download-uri to headers of remote_file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ryan.mango.larson@gmail.com'
 license          'MIT'
 description      'Provides resources for interacting with the artifactory rest API'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.5.0'
 
 supports         'windows', '>= 7.0'
 supports         'centos', '>= 5.0'

--- a/providers/gavc_download.rb
+++ b/providers/gavc_download.rb
@@ -16,13 +16,13 @@ action :download do
                                                  repos: new_resource.repository_keys,
                                                  packaging: new_resource.packaging)
 
-  if new_resource.username && new_resource.password then
-    download_uri = download_uri.sub('://', "://#{new_resource.username}:#{new_resource.password}@")
-  end
   resource_name = "Downloading file #{download_uri} specified by: #{new_resource.to_s}"
   converge_by(resource_name) do
     # Delegate to remote_file for idempotency
     remote_file resource_name do
+      if new_resource.username && new_resource.password then
+        headers "Authorization" => "Basic #{::Base64.encode64("#{new_resource.username}:#{new_resource.password}").chomp()}"
+      end
       source download_uri
       path new_resource.path
     end

--- a/spec/gavc_download_spec.rb
+++ b/spec/gavc_download_spec.rb
@@ -50,13 +50,10 @@ describe 'artifactory_rest_lwrp_test::gavc_download' do
   end
 
   context 'with authentication set' do
-    let(:endpoint_with_auth) { endpoint.sub('://', "://#{username}:#{password}@") }
-    let(:download_uri_path) { "api/storage/#{resolved_repo}/#{group_id}/#{artifact_id}/#{resolved_version}/#{artifact_id}-#{resolved_version}.jar" }
-    let(:download_uri_with_auth) {"#{endpoint_with_auth}/#{download_uri_path}"}
-    let(:download_uri) {"#{endpoint}/#{download_uri_path}"}
+    let(:download_uri) {"#{endpoint}/api/storage/#{resolved_repo}/#{group_id}/#{artifact_id}/#{resolved_version}/#{artifact_id}-#{resolved_version}.jar"}
     let(:username) { 'artifactory_user' }
-    let(:password) { 'artifactory_password' }
-    let(:expected_remote_file_name) { %r[.+#{download_uri_with_auth} specified by: .+#{group_id}.+#{artifact_id}.+#{artifact_version}.+] }
+    let(:password) { 'artifactory_password_!$%&@_special_chars' }
+    let(:headers) { { 'Authorization' => "Basic YXJ0aWZhY3RvcnlfdXNlcjphcnRpZmFjdG9yeV9wYXNzd29yZF8hJCUmQF9z\ncGVjaWFsX2NoYXJz" } }
     subject(:chef_run) do
       mock_artifactory_search_results
 
@@ -78,9 +75,11 @@ describe 'artifactory_rest_lwrp_test::gavc_download' do
                             .with_artifact_id(artifact_id)
                             .with_version(artifact_version)
                             .with_repository_keys(repository_keys)
-                            .with_endpoint(endpoint) }
-    it { is_expected.to create_remote_file(expected_remote_file_name)
-                            .with_source(download_uri_with_auth) }
+                            .with_endpoint(endpoint)
+                            .with_username(username)
+                            .with_password(password) }
+    it { is_expected.to create_remote_file(download_path)
+                            .with(headers: headers) }
   end
 
   context 'with classifier set' do


### PR DESCRIPTION
@rylarson @aogail please review, merge
@grossmane fyi

related to https://github.com/rylarson/chef-artifactory_rest/issues/3

This change gets two improvements for authorization-credentials against artifactory-server:
- no error as soon as credential string has special char like '@'
- 'remote_file' errors doesn't show credentials clear
